### PR TITLE
feat: add ageInMonths to date-known-yes-no variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ## Date of Birth and Age formatting Capture Plugin (with date known support)
 
 if `isDateOfBirthKnown` is unset: `dateOfBirth` and `age` are hidden.
-if `isDateOfBirthKnown` is 'YES': Validates and format a `dateOfBirth` field, and auto-populates the `age` field (disabled).
+if `isDateOfBirthKnown` is 'YES': Validates and format a `dateOfBirth` field, and auto-populates the `age` field (disabled) and the `ageInMonths` field (disabled).
 if `isDateOfBirthKnown` is 'NO': enables `age`, disables `dateOfBirth` and and gets automatically set to the first day of January of the year that makes the age valid (e.g. if Age entered is 22, Date of Birth would be 01/01/2003)
 
 This plugin does not include any visible UI element. It detects changes to the fields.
@@ -9,7 +9,7 @@ This plugin does not include any visible UI element. It detects changes to the f
 NOTE: Disabling and hiding fields is not supported by the Plugin API at the moment - it should be handled with program rules
 
 - If it is invalid, it marks the field with an error.
-- If it is valid, calculates and sets the `age` field.
+- If it is valid, calculates and sets the `age` and `ageInMonths` fields.
 
 A Date of Birth is considered valid if it is a valid date with the format `YYYY-MM-DD` or `YYYYMMDD` and is not in the future.
 If the Date of Birth is entered as `YYYYMMDD` it is reformatted as `YYYY-MM-DD` for consistency.
@@ -46,3 +46,4 @@ Example
 | w75KJ2mc4zz  | dateOfBirth  | Text   |
 | zDhUuAYrxNC  | age          | Text   |
 | zDhUuAYrxNC  | isDobKnown   | Yes/No |
+| zDhUuAYrxNC  | ageInMonths  | Text   |

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dob-formatting-age-calculation-wdk-capture-plugin",
   "author": "EyeSeeTea team",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/Plugin.tsx
+++ b/src/Plugin.tsx
@@ -8,6 +8,8 @@ import { calculateDob } from "./utils/calculateDob";
 import { dateToString } from "./utils/dateToString";
 import { useSetError } from "./hooks/useSetError";
 import { useEffectAfterMount } from "./hooks/useEffectAfterMount";
+import { useSetField } from "./hooks/useSetField";
+import { calculateAgeInMonths } from "./utils/calculateAgeInMonths";
 
 const MAX_AGE = 125; // Maximum age allowed
 const MIN_DOB = new Date("1900-01-01").getTime(); // Minimum date of birth allowed
@@ -21,43 +23,24 @@ const PluginInner = (propsFromParent: IDataEntryPluginProps) => {
 
   const setError = useSetError(propsFromParent);
 
-  const setAge = React.useCallback(
-    (age: string | undefined) => {
-      propsFromParent.setFieldValue({
-        fieldId: PluginFields.age,
-        value: age ?? "",
-        options: {
-          valid: true,
-          touched: true,
-        },
-      });
-    },
-    [propsFromParent]
-  );
-
-  const setDob = React.useCallback(
-    (dob: string | undefined) => {
-      propsFromParent.setFieldValue({
-        fieldId: PluginFields.dateOfBirth,
-        value: dob ?? "",
-        options: {
-          valid: true,
-          touched: true,
-        },
-      });
-    },
-    [propsFromParent]
+  const setAge = useSetField<string>(propsFromParent, PluginFields.age);
+  const setDob = useSetField<string>(propsFromParent, PluginFields.dateOfBirth);
+  const setAgeInMonths = useSetField<string>(
+    propsFromParent,
+    PluginFields.ageInMonths
   );
 
   useEffectAfterMount(() => {
-    // reset age and dateOfBirth when isDobKnown is undefined
+    // reset age, ageInMonths and dateOfBirth when isDobKnown is undefined
     if (isDobKnown === undefined) {
       setDob(undefined);
       setAge(undefined);
+      setAgeInMonths(undefined);
     }
-  }, [isDobKnown, setAge, setDob]);
+  }, [isDobKnown, setAge, setAgeInMonths, setDob]);
 
   React.useEffect(() => {
+    // handle changes in dateOfBirth when isDobKnown is true
     if (isDobKnown === undefined || isDobKnown === "false") {
       return;
     }
@@ -87,13 +70,14 @@ const PluginInner = (propsFromParent: IDataEntryPluginProps) => {
       );
     } else {
       setDob(formattedDateOfBirth);
-      setAge(
-        calculateAge(formattedDateOfBirth) + "" // setting an integer seems to cause an error
-      );
+      // setting an integer as value seems to cause an error
+      setAge(calculateAge(formattedDateOfBirth) + "");
+      setAgeInMonths(calculateAgeInMonths(formattedDateOfBirth) + "");
     }
-  }, [dateOfBirth, isDobKnown, setError, setDob, setAge]);
+  }, [dateOfBirth, isDobKnown, setError, setDob, setAge, setAgeInMonths]);
 
   React.useEffect(() => {
+    // handle changes in age when isDobKnown is false
     if (isDobKnown === undefined || isDobKnown === "true") {
       return;
     }

--- a/src/Plugin.tsx
+++ b/src/Plugin.tsx
@@ -94,8 +94,9 @@ const PluginInner = (propsFromParent: IDataEntryPluginProps) => {
     } else if (ageParsed > MAX_AGE) {
       setError(PluginFields.age, age, i18n.t("Age cannot be greater than 125"));
     } else {
-      const calculatedDob = calculateDob(ageParsed);
-      setDob(dateToString(calculatedDob));
+      const formattedEstimatedDob = dateToString(calculateDob(ageParsed));
+      setDob(formattedEstimatedDob);
+      setAgeInMonths(calculateAgeInMonths(formattedEstimatedDob) + "");
     }
   }, [age, isDobKnown, setError, setDob]);
 

--- a/src/Plugin.types.ts
+++ b/src/Plugin.types.ts
@@ -48,6 +48,7 @@ export const PluginFields = {
   dateOfBirth: "dateOfBirth",
   age: "age",
   isDobKnown: "isDobKnown",
+  ageInMonths: "ageInMonths",
 } as const;
 
 export type PluginField = (typeof PluginFields)[keyof typeof PluginFields];

--- a/src/hooks/useSetField.ts
+++ b/src/hooks/useSetField.ts
@@ -1,0 +1,21 @@
+import React from "react";
+import { IDataEntryPluginProps, PluginField } from "../Plugin.types";
+
+export function useSetField<T>(
+  propsFromParent: IDataEntryPluginProps,
+  fieldId: PluginField
+) {
+  return React.useCallback(
+    (value: T | undefined) => {
+      propsFromParent.setFieldValue({
+        fieldId,
+        value: value ?? "",
+        options: {
+          valid: true,
+          touched: true,
+        },
+      });
+    },
+    [propsFromParent, fieldId]
+  );
+}

--- a/src/utils/calculateAge.test.ts
+++ b/src/utils/calculateAge.test.ts
@@ -1,25 +1,15 @@
 import { calculateAge } from "../utils/calculateAge";
+import { mockCurrentDate } from "./testUtils";
 
 describe("calculateAge", () => {
-  const originalDate = Date;
-
-  const MOCK_DATE_NOW = "2025-05-12T00:00:00Z";
+  const dateMock = mockCurrentDate("2025-05-12T00:00:00Z");
 
   beforeAll(() => {
-    global.Date = class extends Date {
-      constructor(...args: any[]) {
-        if (args.length) {
-          // @ts-ignore
-          super(...args);
-        } else {
-          super(MOCK_DATE_NOW);
-        }
-      }
-    } as typeof Date;
+    dateMock.setup();
   });
 
   afterAll(() => {
-    global.Date = originalDate;
+    dateMock.teardown();
   });
 
   it("should return the correct age for a past date", () => {

--- a/src/utils/calculateAgeInMonths.test.ts
+++ b/src/utils/calculateAgeInMonths.test.ts
@@ -1,0 +1,55 @@
+import { calculateAgeInMonths } from "../utils/calculateAgeInMonths";
+import { mockCurrentDate } from "./testUtils";
+
+describe("calculateAgeInMonths", () => {
+  const dateMock = mockCurrentDate("2025-05-12T00:00:00Z");
+
+  beforeAll(() => {
+    dateMock.setup();
+  });
+
+  afterAll(() => {
+    dateMock.teardown();
+  });
+
+  it("should return the correct age in months for exact year anniversaries", () => {
+    expect(calculateAgeInMonths("2024-05-12")).toBe(12);
+    expect(calculateAgeInMonths("2023-05-12")).toBe(24);
+    expect(calculateAgeInMonths("2022-05-12")).toBe(36);
+  });
+
+  it("should return 0 for dates in the same month or in the future", () => {
+    expect(calculateAgeInMonths("2025-05-01")).toBe(0);
+    expect(calculateAgeInMonths("2025-05-11")).toBe(0);
+    expect(calculateAgeInMonths("2025-05-13")).toBe(0);
+    expect(calculateAgeInMonths("2027-01-01")).toBe(0);
+    expect(calculateAgeInMonths("2024-05-13")).toBe(11); // 11 months ago + 1 day
+  });
+
+  it("should return the correct age in months for different months", () => {
+    expect(calculateAgeInMonths("2025-04-12")).toBe(1);
+    expect(calculateAgeInMonths("2025-03-12")).toBe(2);
+    expect(calculateAgeInMonths("2025-01-12")).toBe(4);
+    expect(calculateAgeInMonths("2024-12-12")).toBe(5);
+    expect(calculateAgeInMonths("2025-04-01")).toBe(1); // ~1 month ago
+    expect(calculateAgeInMonths("2025-03-01")).toBe(2); // ~2 months ago
+  });
+
+  it("should handle cross-year calculations correctly", () => {
+    expect(calculateAgeInMonths("2024-05-11")).toBe(12); // 1 year + 1 day
+    expect(calculateAgeInMonths("2024-01-12")).toBe(16); // 1 year + 4 months
+    expect(calculateAgeInMonths("2023-12-12")).toBe(17); // 1 year + 5 months
+    expect(calculateAgeInMonths("2000-05-12")).toBe(25 * 12); // 25 years = 300 months
+    expect(calculateAgeInMonths("1990-01-01")).toBe(35 * 12 + 4); // ~35 years + 4 months
+  });
+
+  it("should handle leap years correctly", () => {
+    expect(calculateAgeInMonths("2024-02-29")).toBe(14); // From Feb 29, 2024 to May 12, 2025 = 14 months
+  });
+
+  it("should handle day adjustments correctly", () => {
+    expect(calculateAgeInMonths("2025-04-10")).toBe(1); // Same month, past day -> 1 month
+    expect(calculateAgeInMonths("2024-06-15")).toBe(10); // Future day in birth month -> 10 months
+    expect(calculateAgeInMonths("2024-06-10")).toBe(11); // Past day in birth month -> 11 months
+  });
+});

--- a/src/utils/calculateAgeInMonths.ts
+++ b/src/utils/calculateAgeInMonths.ts
@@ -1,0 +1,23 @@
+/**
+ * Calculates the age in months, based on a given date string.
+ *
+ * @param dateString - The date of birth in string format (e.g., "YYYY-MM-DD").
+ * @returns The calculated age in months as a number.
+ *
+ */
+export function calculateAgeInMonths(dateString: string): number {
+  const today = new Date();
+  const birthDate = new Date(dateString);
+  if (birthDate > today) {
+    return 0;
+  }
+  let months = (today.getFullYear() - birthDate.getFullYear()) * 12;
+  months += today.getMonth() - birthDate.getMonth();
+
+  // Adjust if the current day is before the birth day in the month
+  if (today.getDate() < birthDate.getDate()) {
+    months--;
+  }
+
+  return Math.max(0, months);
+}

--- a/src/utils/calculateDob.test.ts
+++ b/src/utils/calculateDob.test.ts
@@ -1,25 +1,16 @@
 import { calculateDob } from "./calculateDob";
+import { mockCurrentDate } from "./testUtils";
 
 describe("calculateDob", () => {
-  const originalDate = Date;
-
   const MOCK_DATE_NOW = "2025-06-24T00:00:00Z";
+  const dateMock = mockCurrentDate(MOCK_DATE_NOW);
 
   beforeAll(() => {
-    global.Date = class extends Date {
-      constructor(...args: any[]) {
-        if (args.length) {
-          // @ts-ignore
-          super(...args);
-        } else {
-          super(MOCK_DATE_NOW);
-        }
-      }
-    } as typeof Date;
+    dateMock.setup();
   });
 
   afterAll(() => {
-    global.Date = originalDate;
+    dateMock.teardown();
   });
 
   it("should return January 1st of the correct birth year for a given age", () => {

--- a/src/utils/testUtils.ts
+++ b/src/utils/testUtils.ts
@@ -1,0 +1,28 @@
+/**
+ * Mocks the global Date constructor to return a fixed date when called without arguments.
+ *
+ * @param mockDateString - The ISO date string to use as the mocked "now" date
+ * @returns An object with setup and teardown functions to use in beforeAll/afterAll
+ */
+export function mockCurrentDate(mockDateString: string) {
+  const originalDate = Date;
+
+  const setup = () => {
+    global.Date = class extends Date {
+      constructor(...args: any[]) {
+        if (args.length) {
+          // @ts-ignore
+          super(...args);
+        } else {
+          super(mockDateString);
+        }
+      }
+    } as typeof Date;
+  };
+
+  const teardown = () => {
+    global.Date = originalDate;
+  };
+
+  return { setup, teardown };
+}


### PR DESCRIPTION
Task: https://app.clickup.com/t/869aedje0

When setting `age`, also a new field `ageInMonths` is populated.

refactor: extract `useSetField` hook. Extract `mockCurrentDate` for tests.