### PR TITLE
fix: init plugin state when in edit mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dob-formatting-age-calculation-wdk-capture-plugin",
   "author": "EyeSeeTea team",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "description": "",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/Plugin.tsx
+++ b/src/Plugin.tsx
@@ -30,7 +30,8 @@ const PluginInner = (propsFromParent: IDataEntryPluginProps) => {
   const setError = useSetError(propsFromParent);
 
   const { pluginState, setFields } = useSetFields(
-    propsFromParent.setFieldValue
+    propsFromParent.setFieldValue,
+    propsFromParent.values,
   );
 
   const previousAge = usePrevious(age);

--- a/src/hooks/useSetFields.ts
+++ b/src/hooks/useSetFields.ts
@@ -6,10 +6,11 @@ import {
 } from "../Plugin.types";
 
 export function useSetFields(
-  setFieldValue: IDataEntryPluginProps["setFieldValue"]
+  setFieldValue: IDataEntryPluginProps["setFieldValue"],
+  initialValues?: Partial<IDataEntryPluginProps["values"]>,
 ) {
   const pluginState = React.useRef<Partial<IDataEntryPluginProps["values"]>>(
-    {}
+    initialValues ?? {},
   );
   const setFields = React.useCallback(
     (fields: Partial<IDataEntryPluginProps["values"]>) => {


### PR DESCRIPTION
**Task:** https://app.clickup.com/t/869buw0tr

When opening for edit an existing record in Capture, the plugin state was blank, causing inconsistent behavior

