### PR TITLE
fix: stale program-rule effects when plugin updates multiple fields

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dob-formatting-age-calculation-wdk-capture-plugin",
   "author": "EyeSeeTea team",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "description": "",
   "license": "BSD-3-Clause",
   "private": true,

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "dob-formatting-age-calculation-wdk-capture-plugin",
   "author": "EyeSeeTea team",
-  "version": "1.0.7",
+  "version": "1.0.8",
   "description": "",
   "license": "BSD-3-Clause",
   "private": true,

--- a/src/Plugin.tsx
+++ b/src/Plugin.tsx
@@ -25,8 +25,13 @@ const MIN_DOB = new Date("1900-01-01").getTime(); // Minimum date of birth allow
 const MAX_CALC_AGE_IN_MONTHS_YEARS = 5; // Maximum age in years to calculate age in months
 
 const PluginInner = (propsFromParent: IDataEntryPluginProps) => {
-  const { isDobKnown, age, dateOfBirth, ageInMonths } =
-    propsFromParent.values as PluginValues;
+  const rawValues = propsFromParent.values as PluginValues;
+  const isDobKnown = rawValues.isDobKnown;
+  // Trim string inputs so the trailing-space artifact from the setError HACK
+  // (see useSetError) can't pile up across re-runs or leak into validators.
+  const age = rawValues.age?.trim();
+  const dateOfBirth = rawValues.dateOfBirth?.trim();
+  const ageInMonths = rawValues.ageInMonths?.trim();
   const setError = useSetError(propsFromParent);
 
   const { pluginState, setFields } = useSetFields(
@@ -93,9 +98,9 @@ const PluginInner = (propsFromParent: IDataEntryPluginProps) => {
           ? calculateAgeInMonths(formattedDateOfBirth)
           : "";
       setFields({
+        [PluginFields.dateOfBirth]: formattedDateOfBirth,
         [PluginFields.age]: ageCalculated + "",
         [PluginFields.ageInMonths]: calculatedAgeInMonths + "",
-        [PluginFields.dateOfBirth]: formattedDateOfBirth,
       });
     }
   }, [dateOfBirth, setError, setFields]);

--- a/src/hooks/useSetError.ts
+++ b/src/hooks/useSetError.ts
@@ -2,17 +2,22 @@ import React from "react";
 import { IDataEntryPluginProps, PluginField } from "../Plugin.types";
 
 export function useSetError(propsFromParent: IDataEntryPluginProps) {
+  const propsRef = React.useRef(propsFromParent);
+  React.useEffect(() => {
+    propsRef.current = propsFromParent;
+  }, [propsFromParent]);
+
   const setError = React.useCallback(
     (field: PluginField, value: string, error: string) => {
       // return early if the field already has an error to avoid infinite loops later
-      if (propsFromParent.errors[field]) {
+      if (propsRef.current.errors[field]) {
         return;
       }
 
       // HACK: set the value twice with different values to trigger the error message
       // If this is not done, the error message will be show only after blurring the next field
       // tested with Capture 101.32.5
-      propsFromParent.setFieldValue({
+      propsRef.current.setFieldValue({
         fieldId: field,
         value: value + " ",
         options: {
@@ -21,7 +26,7 @@ export function useSetError(propsFromParent: IDataEntryPluginProps) {
           error,
         },
       });
-      propsFromParent.setFieldValue({
+      propsRef.current.setFieldValue({
         fieldId: field,
         value: value,
         options: {
@@ -31,7 +36,7 @@ export function useSetError(propsFromParent: IDataEntryPluginProps) {
         },
       });
     },
-    [propsFromParent.setFieldValue, propsFromParent.errors]
+    []
   );
   return setError;
 }

--- a/src/hooks/useSetFields.ts
+++ b/src/hooks/useSetFields.ts
@@ -19,22 +19,35 @@ export function useSetFields(
 
   const setFields = React.useCallback(
     (fields: Partial<IDataEntryPluginProps["values"]>) => {
-      Object.entries(fields).forEach(([fieldId, value]) => {
-        if (
-          Object.values(PluginFields).includes(fieldId as PluginField) === false
-        ) {
-          return;
-        }
+      const entries = Object.entries(fields).filter(([fieldId]) =>
+        Object.values(PluginFields).includes(fieldId as PluginField)
+      );
+
+      // Update pluginState synchronously up front so effects guarded by
+      // `value === pluginState.current.<field>` don't re-fire mid-dispatch.
+      for (const [fieldId, value] of entries) {
         pluginState.current[fieldId as PluginField] = value;
-        setFieldValueRef.current({
-          fieldId: fieldId as PluginField,
-          value: value ?? "",
-          options: {
-            valid: true,
-            touched: true,
-          },
-        });
-      });
+      }
+
+      // Capture runs program rules independently for every setFieldValue call,
+      // reading the current Redux state and overlaying only the field being
+      // committed. Firing all calls synchronously means each rules eval sees
+      // stale values for the other fields, and the last dispatch wins. Yield a
+      // macrotask between calls so each subsequent eval runs against a state
+      // that already contains the previous commit.
+      void (async () => {
+        for (const [fieldId, value] of entries) {
+          setFieldValueRef.current({
+            fieldId: fieldId as PluginField,
+            value: value ?? "",
+            options: {
+              valid: true,
+              touched: true,
+            },
+          });
+          await new Promise((resolve) => setTimeout(resolve, 0));
+        }
+      })();
     },
     []
   );

--- a/src/hooks/useSetFields.ts
+++ b/src/hooks/useSetFields.ts
@@ -12,6 +12,11 @@ export function useSetFields(
   const pluginState = React.useRef<Partial<IDataEntryPluginProps["values"]>>(
     initialValues ?? {},
   );
+  const setFieldValueRef = React.useRef(setFieldValue);
+  React.useEffect(() => {
+    setFieldValueRef.current = setFieldValue;
+  }, [setFieldValue]);
+
   const setFields = React.useCallback(
     (fields: Partial<IDataEntryPluginProps["values"]>) => {
       Object.entries(fields).forEach(([fieldId, value]) => {
@@ -21,7 +26,7 @@ export function useSetFields(
           return;
         }
         pluginState.current[fieldId as PluginField] = value;
-        setFieldValue({
+        setFieldValueRef.current({
           fieldId: fieldId as PluginField,
           value: value ?? "",
           options: {
@@ -31,7 +36,7 @@ export function useSetFields(
         });
       });
     },
-    [setFieldValue]
+    []
   );
   return { setFields, pluginState };
 }

--- a/src/hooks/useSetFields.ts
+++ b/src/hooks/useSetFields.ts
@@ -19,6 +19,13 @@ export function useSetFields(
 
   const setFields = React.useCallback(
     (fields: Partial<IDataEntryPluginProps["values"]>) => {
+      // TODO: callers rely on dispatch order (e.g. dateOfBirth must commit
+      // before age/ageInMonths so program rules don't blank them out), and
+      // that order currently comes from the object literal's insertion order.
+      // ES2020 guarantees this for non-integer string keys, but it's fragile
+      // — any spread/copy/Map round-trip silently breaks it. Consider changing
+      // the API to take an ordered array, or sorting entries here against a
+      // canonical order defined in PluginFields.
       const entries = Object.entries(fields).filter(([fieldId]) =>
         Object.values(PluginFields).includes(fieldId as PluginField)
       );


### PR DESCRIPTION
**Task:**  https://app.clickup.com/t/869czvkrw

**Summary:**

- `useSetError` / `useSetFields`: capture `propsFromParent` and `setFieldValue` in refs so the returned `useCallback`s have stable identities. Effects in `Plugin.tsx` that depend on `setError` / `setFields` no longer re-run on every parent render. 
  - Observed after upgrading to Capture 105.13.5; root cause is the form-perf refactor introduced in 105.10.0, where setFieldValue's identity now changes on every form value update.
- `useSetFields`: serialize the per-field `setFieldValue` dispatches. Capture re-runs the program-rules engine independently for every plugin `setFieldValue` call, reading the current Redux state and overlaying only the field being committed. Firing the three calls synchronously meant each rules eval saw stale values for the other two fields, and the last dispatch's effects won. Pre-populate `pluginState.current` up front (so the plugin's own effect guards don't re-fire mid-loop), then dispatch one field at a time inside an async IIFE with a macrotask yield between calls, so each subsequent rules eval runs against a Redux state that already contains the previous commit.
  - This was a latent bug but became evident after the previous refactor
- Already included a version bump to 1.0.7.

**Follow-up fix: input trimming + dispatch order in dob success branch**

While testing the error flow on top of this PR, surfaced two related issues:

1. **Trailing-space pile-up.** `useSetError`'s double-`setFieldValue` HACK writes `value + " "` then `value` back. Because Capture 105.10+ feeds every dispatch back into the plugin synchronously, an effect that re-fires on the intermediate `"abc "` state would call `setError` again with the now-spaced value and accumulate spaces across re-runs (and leak into the validators). Fixed by trimming `age`, `dateOfBirth`, and `ageInMonths` at destructure — the effects' dep arrays then see the trimmed value, so the HACK's `"abc "` → `"abc"` round-trip is invisible to them.

2. **Age not recalculated after fixing an invalid dob.** Repro: enter an invalid date → error shown, age/ageInMonths hidden by the program rule → fix the dob → fields reappear but `age` stays empty. Root cause: in the dob success branch, `setFields({ age, ageInMonths, dateOfBirth })` dispatched `dateOfBirth` last (insertion order). Because `useSetFields` yields a macrotask between dispatches and Capture re-runs program rules per dispatch, `age` and `ageInMonths` were committed while `dateOfBirth` still had the error, so the "hide when invalid" rule blanked them out. By the time `dateOfBirth` finally committed and the rule cleared, the calculated values were already gone. Fixed by dispatching `dateOfBirth` first, matching what the age and ageInMonths effects already do.

Also added a TODO in `useSetFields` flagging that the dispatch order is currently load-bearing and comes from object-literal insertion order — ES2020 guarantees that for non-integer string keys, but it's fragile to refactors (spread, copy, Map round-trip). Worth promoting to an explicit ordered-array API or an internal sort against a canonical order, but left as a follow-up.

**Testing**

Open a record in Edit mode with `isDobKnown=true`, `dob=2010-01-01`, `age=16`
(`ageInMonths` hidden by program rule "hide when age > 5").

| Action | Expected | Before | After |
|---|---|---|---|
| dob → 2021-01-01 (age 5) | `ageInMonths` visible | "Age in months was blanked out" toast, field hidden | visible ✓ |
| dob → 2022-01-01 (age 4) | visible | visible | visible ✓ |
| dob → 2012-01-01 (age 14) | hidden | value emptied but field still visible | hidden ✓ |
